### PR TITLE
Update to Git 2.48 and fix issue with runtime prefix not computed properly

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -3,7 +3,7 @@ export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_CATEGORIES="development source_control"
 
 # bump: git-version /GIT_VERSION="(.*)"/ https://github.com/git/git.git|*
-GIT_VERSION="2.47.1"
+GIT_VERSION="2.48.0"
 
 export ZOPEN_DEV_URL="https://github.com/git/git.git"
 export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash tar check_python"
@@ -164,8 +164,6 @@ ZZ
 
 zopen_append_to_zoslib_env() {
 cat <<EOF
-GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
-GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 ZOPEN_GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 GIT_CONFIG_SYSTEM|set|PROJECT_ROOT/etc/gitconfig

--- a/buildenv
+++ b/buildenv
@@ -6,11 +6,11 @@ export ZOPEN_CATEGORIES="development source_control"
 GIT_VERSION="2.48.0"
 
 export ZOPEN_DEV_URL="https://github.com/git/git.git"
-export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash tar check_python"
+export ZOPEN_DEV_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext coreutils diffutils bash tar check_python gawk"
 
 export ZOPEN_STABLE_URL="https://github.com/git/git.git"
 export ZOPEN_STABLE_TAG="v${GIT_VERSION}"
-export ZOPEN_STABLE_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext gzip tar coreutils zoslib diffutils ncurses bash sed libpcre2 tar check_python"
+export ZOPEN_STABLE_DEPS="curl git make m4 perl autoconf automake help2man texinfo xz zlib openssl expat gettext gzip tar coreutils zoslib diffutils ncurses bash sed libpcre2 tar check_python gawk"
 
 #
 # Note the 'man' tarball release is numbered independently from the 'git' release.
@@ -112,7 +112,9 @@ zopen_post_install()
   set -e
   $1/bin/git clone https://github.com/ZOSOpenTools/gitport.git httpgitport
   $1/bin/git clone git@github.com:ZOSOpenTools/gitport.git gitport
+  rm -rf httpgitport gitport 
   set +e
+  $1/bin/git clone https://github.com/ZOSOpenTools/gitport.git httpgitport 2>&1 | grep -q "RUNTIME_PREFIX requested, but prefix computation failed" && exit 1
 
   mkdir -p "$1/etc"
   touch "$1/etc/gitconfig" # empty it out to avoid error with --system option
@@ -164,6 +166,8 @@ ZZ
 
 zopen_append_to_zoslib_env() {
 cat <<EOF
+GIT_TEMPLATE_DIR|set|PROJECT_ROOT/share/git-core/templates
+GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 ZOPEN_GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 GIT_CONFIG_SYSTEM|set|PROJECT_ROOT/etc/gitconfig

--- a/stable-patches/Makefile.patch
+++ b/stable-patches/Makefile.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 97e8385b66..3c7078115f 100644
+index 97e8385b66..08ab16ee92 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -20,6 +20,8 @@ include shared.mak
@@ -20,7 +20,7 @@ index 97e8385b66..3c7078115f 100644
  # Define NO_PERL if you do not want Perl scripts or libraries at all.
  #
  # Define NO_PERL_CPAN_FALLBACKS if you do not want to install bundled
-@@ -896,9 +900,15 @@ BINDIR_PROGRAMS_NO_X += git-cvsserver
+@@ -896,15 +900,22 @@ BINDIR_PROGRAMS_NO_X += git-cvsserver
  ifndef SHELL_PATH
  	SHELL_PATH = /bin/sh
  endif
@@ -36,7 +36,14 @@ index 97e8385b66..3c7078115f 100644
  ifndef PYTHON_PATH
  	PYTHON_PATH = /usr/bin/python
  endif
-@@ -1372,7 +1382,7 @@ UNIT_TEST_OBJS += $(UNIT_TEST_DIR)/lib-reftable.o
+ 
+ export PERL_PATH
+ export PYTHON_PATH
++export PERL_PATH_FOR_SCRIPTS
+ 
+ TEST_SHELL_PATH = $(SHELL_PATH)
+ 
+@@ -1372,7 +1383,7 @@ UNIT_TEST_OBJS += $(UNIT_TEST_DIR)/lib-reftable.o
  
  # xdiff and reftable libs may in turn depend on what is in libgit.a
  GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB) $(REFTABLE_LIB) $(LIB_FILE)
@@ -45,7 +52,7 @@ index 97e8385b66..3c7078115f 100644
  
  GIT_USER_AGENT = git/$(GIT_VERSION)
  
-@@ -2298,9 +2308,10 @@ perllibdir_relative_SQ = $(subst ','\'',$(perllibdir_relative))
+@@ -2298,9 +2309,10 @@ perllibdir_relative_SQ = $(subst ','\'',$(perllibdir_relative))
  gitwebdir_SQ = $(subst ','\'',$(gitwebdir))
  gitwebstaticdir_SQ = $(subst ','\'',$(gitwebstaticdir))
  
@@ -57,7 +64,7 @@ index 97e8385b66..3c7078115f 100644
  PYTHON_PATH_SQ = $(subst ','\'',$(PYTHON_PATH))
  TCLTK_PATH_SQ = $(subst ','\'',$(TCLTK_PATH))
  DIFF_SQ = $(subst ','\'',$(DIFF))
-@@ -2543,7 +2554,7 @@ hook-list.h: generate-hooklist.sh Documentation/githooks.txt
+@@ -2543,7 +2555,7 @@ hook-list.h: generate-hooklist.sh Documentation/githooks.txt
  
  SCRIPT_DEFINES = $(SHELL_PATH_SQ):$(DIFF_SQ):\
  	$(localedir_SQ):$(USE_GETTEXT_SCHEME):$(SANE_TOOL_PATH_SQ):\
@@ -66,12 +73,12 @@ index 97e8385b66..3c7078115f 100644
  	$(perllibdir_SQ)
  GIT-SCRIPT-DEFINES: FORCE
  	@FLAGS='$(SCRIPT_DEFINES)'; \
-@@ -3181,7 +3192,7 @@ GIT-BUILD-OPTIONS: FORCE
- 		-e "s|@NO_UNIX_SOCKETS@|\'$(NO_UNIX_SOCKETS)\'|" \
- 		-e "s|@PAGER_ENV@|\'$(PAGER_ENV)\'|" \
- 		-e "s|@PERL_LOCALEDIR@|\'$(perl_localedir_SQ)\'|" \
--		-e "s|@PERL_PATH@|\'$(PERL_PATH_SQ)\'|" \
-+		-e "s|@PERL_PATH@|\'$(PERL_PATH_FOR_SCRIPTS_SQ)\'|" \
- 		-e "s|@PYTHON_PATH@|\'$(PYTHON_PATH_SQ)\'|" \
- 		-e "s|@RUNTIME_PREFIX@|\'$(RUNTIME_PREFIX_OPTION)\'|" \
- 		-e "s|@SANITIZE_ADDRESS@|\'$(SANITIZE_ADDRESS)\'|" \
+@@ -2794,7 +2806,7 @@ endif
+ 
+ exec-cmd.sp exec-cmd.s exec-cmd.o: GIT-PREFIX
+ exec-cmd.sp exec-cmd.s exec-cmd.o: EXTRA_CPPFLAGS = \
+-	'-DGIT_EXEC_PATH="$(gitexecdir_SQ)"' \
++	'-DGIT_EXEC_PATH="$(gitexecdir_relative_SQ)"' \
+ 	'-DGIT_LOCALE_PATH="$(localedir_relative_SQ)"' \
+ 	'-DBINDIR="$(bindir_relative_SQ)"' \
+ 	'-DFALLBACK_RUNTIME_PREFIX="$(prefix_SQ)"'

--- a/stable-patches/Makefile.patch
+++ b/stable-patches/Makefile.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index cac3452..c70a236 100644
+index 97e8385b66..3c7078115f 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -8,6 +8,8 @@ include shared.mak
+@@ -20,6 +20,8 @@ include shared.mak
  #
  # Define SHELL_PATH to a POSIX shell if your /bin/sh is broken.
  #
@@ -11,7 +11,7 @@ index cac3452..c70a236 100644
  # Define SANE_TOOL_PATH to a colon-separated list of paths to prepend
  # to PATH if your tools in /usr/bin are broken.
  #
-@@ -300,6 +302,8 @@ include shared.mak
+@@ -215,6 +217,8 @@ include shared.mak
  #
  # Define PERL_PATH to the path of your Perl binary (usually /usr/bin/perl).
  #
@@ -20,7 +20,7 @@ index cac3452..c70a236 100644
  # Define NO_PERL if you do not want Perl scripts or libraries at all.
  #
  # Define NO_PERL_CPAN_FALLBACKS if you do not want to install bundled
-@@ -839,9 +843,15 @@ BINDIR_PROGRAMS_NO_X += git-cvsserver
+@@ -896,9 +900,15 @@ BINDIR_PROGRAMS_NO_X += git-cvsserver
  ifndef SHELL_PATH
  	SHELL_PATH = /bin/sh
  endif
@@ -36,7 +36,7 @@ index cac3452..c70a236 100644
  ifndef PYTHON_PATH
  	PYTHON_PATH = /usr/bin/python
  endif
-@@ -1268,7 +1278,7 @@ THIRD_PARTY_SOURCES += sha1dc/%
+@@ -1372,7 +1382,7 @@ UNIT_TEST_OBJS += $(UNIT_TEST_DIR)/lib-reftable.o
  
  # xdiff and reftable libs may in turn depend on what is in libgit.a
  GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB) $(REFTABLE_LIB) $(LIB_FILE)
@@ -45,7 +45,7 @@ index cac3452..c70a236 100644
  
  GIT_USER_AGENT = git/$(GIT_VERSION)
  
-@@ -2110,9 +2120,10 @@ perllibdir_relative_SQ = $(subst ','\'',$(perllibdir_relative))
+@@ -2298,9 +2308,10 @@ perllibdir_relative_SQ = $(subst ','\'',$(perllibdir_relative))
  gitwebdir_SQ = $(subst ','\'',$(gitwebdir))
  gitwebstaticdir_SQ = $(subst ','\'',$(gitwebstaticdir))
  
@@ -57,7 +57,7 @@ index cac3452..c70a236 100644
  PYTHON_PATH_SQ = $(subst ','\'',$(PYTHON_PATH))
  TCLTK_PATH_SQ = $(subst ','\'',$(TCLTK_PATH))
  DIFF_SQ = $(subst ','\'',$(DIFF))
-@@ -2332,7 +2343,7 @@ hook-list.h: generate-hooklist.sh Documentation/githooks.txt
+@@ -2543,7 +2554,7 @@ hook-list.h: generate-hooklist.sh Documentation/githooks.txt
  
  SCRIPT_DEFINES = $(SHELL_PATH_SQ):$(DIFF_SQ):\
  	$(localedir_SQ):$(USE_GETTEXT_SCHEME):$(SANE_TOOL_PATH_SQ):\
@@ -66,95 +66,12 @@ index cac3452..c70a236 100644
  	$(perllibdir_SQ)
  GIT-SCRIPT-DEFINES: FORCE
  	@FLAGS='$(SCRIPT_DEFINES)'; \
-@@ -2349,7 +2360,7 @@ sed -e '1s|#!.*/sh|#!$(SHELL_PATH_SQ)|' \
-     -e 's/@@USE_GETTEXT_SCHEME@@/$(USE_GETTEXT_SCHEME)/g' \
-     -e $(BROKEN_PATH_FIX) \
-     -e 's|@@GITWEBDIR@@|$(gitwebdir_SQ)|g' \
--    -e 's|@@PERL@@|$(PERL_PATH_SQ)|g' \
-+    -e 's|@@PERL@@|$(PERL_PATH_FOR_SCRIPTS_SQ)|g' \
-     -e 's|@@PAGER_ENV@@|$(PAGER_ENV_SQ)|g' \
-     $@.sh >$@+
- endef
-@@ -2403,7 +2414,7 @@ PERL_DEFINES += $(gitexecdir) $(perllibdir) $(localedir)
- $(SCRIPT_PERL_GEN): % : %.perl GIT-PERL-DEFINES GIT-PERL-HEADER GIT-VERSION-FILE
- 	$(QUIET_GEN) \
- 	sed -e '1{' \
--	    -e '	s|#!.*perl|#!$(PERL_PATH_SQ)|' \
-+	    -e '	s|#!.*perl|#!$(PERL_PATH_FOR_SCRIPTS_SQ)|' \
- 	    -e '	r GIT-PERL-HEADER' \
- 	    -e '	G' \
- 	    -e '}' \
-diff --git a/git-gui/Makefile b/git-gui/Makefile
-index 56c85a8..72934a9 100644
---- a/git-gui/Makefile
-+++ b/git-gui/Makefile
-@@ -30,6 +30,9 @@ NONTCL_LIBFILES = \
- ifndef SHELL_PATH
- 	SHELL_PATH = /bin/sh
- endif
-+ifndef SHELL_PATH_FOR_SCRIPTS
-+	SHELL_PATH_FOR_SCRIPTS = /bin/sh
-+endif
- 
- ifndef gitexecdir
- 	gitexecdir := $(shell git --exec-path)
-@@ -124,7 +127,7 @@ endif
- 
- DESTDIR_SQ = $(subst ','\'',$(DESTDIR))
- gitexecdir_SQ = $(subst ','\'',$(gitexecdir))
--SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
-+SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH_FOR_SCRIPTS))
- TCL_PATH_SQ = $(subst ','\'',$(TCL_PATH))
- TCLTK_PATH_SQ = $(subst ','\'',$(TCLTK_PATH))
- TCLTK_PATH_SED = $(subst ','\'',$(subst \,\\,$(TCLTK_PATH)))
-diff --git a/t/Makefile b/t/Makefile
-index 882782a..bacb8ef 100644
---- a/t/Makefile
-+++ b/t/Makefile
-@@ -9,8 +9,11 @@ include ../shared.mak
- -include ../config.mak.autogen
- -include ../config.mak
- 
--#GIT_TEST_OPTS = --verbose --debug
-+GIT_TEST_OPTS = --verbose --debug
- SHELL_PATH ?= $(SHELL)
-+ifndef SHELL_PATH_FOR_SCRIPTS
-+	SHELL_PATH_FOR_SCRIPTS = /bin/sh
-+endif
- TEST_SHELL_PATH ?= $(SHELL_PATH)
- PERL_PATH ?= /usr/bin/perl
- TAR ?= $(TAR)
-@@ -28,7 +31,7 @@ CHAINLINTTMP = chainlinttmp
- endif
- 
- # Shell quote;
--SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
-+SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH_FOR_SCRIPTS))
- TEST_SHELL_PATH_SQ = $(subst ','\'',$(TEST_SHELL_PATH))
- PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
- TEST_RESULTS_DIRECTORY_SQ = $(subst ','\'',$(TEST_RESULTS_DIRECTORY))
-diff --git a/templates/Makefile b/templates/Makefile
-index 367ad00..251ba68 100644
---- a/templates/Makefile
-+++ b/templates/Makefile
-@@ -12,12 +12,18 @@ template_instdir ?= $(prefix)/share/git-core/templates
- ifndef SHELL_PATH
- 	SHELL_PATH = /bin/sh
- endif
-+ifndef SHELL_PATH_FOR_SCRIPTS
-+	SHELL_PATH_FOR_SCRIPTS = /bin/sh
-+endif
- ifndef PERL_PATH
- 	PERL_PATH = perl
- endif
-+ifndef PERL_PATH_FOR_SCRIPTS
-+	PERL_PATH_FOR_SCRIPTS = /usr/bin/perl
-+endif
- 
--SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
--PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH))
-+SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH_FOR_SCRIPTS))
-+PERL_PATH_SQ = $(subst ','\'',$(PERL_PATH_FOR_SCRIPTS))
- 
- # Shell quote (do not use $(call) to accommodate ancient setups);
- DESTDIR_SQ = $(subst ','\'',$(DESTDIR))
+@@ -3181,7 +3192,7 @@ GIT-BUILD-OPTIONS: FORCE
+ 		-e "s|@NO_UNIX_SOCKETS@|\'$(NO_UNIX_SOCKETS)\'|" \
+ 		-e "s|@PAGER_ENV@|\'$(PAGER_ENV)\'|" \
+ 		-e "s|@PERL_LOCALEDIR@|\'$(perl_localedir_SQ)\'|" \
+-		-e "s|@PERL_PATH@|\'$(PERL_PATH_SQ)\'|" \
++		-e "s|@PERL_PATH@|\'$(PERL_PATH_FOR_SCRIPTS_SQ)\'|" \
+ 		-e "s|@PYTHON_PATH@|\'$(PYTHON_PATH_SQ)\'|" \
+ 		-e "s|@RUNTIME_PREFIX@|\'$(RUNTIME_PREFIX_OPTION)\'|" \
+ 		-e "s|@SANITIZE_ADDRESS@|\'$(SANITIZE_ADDRESS)\'|" \

--- a/stable-patches/config.c.patch
+++ b/stable-patches/config.c.patch
@@ -1,18 +1,18 @@
 diff --git a/config.c b/config.c
-index 6421894614..aa3c885d39 100644
+index 50f2d17b39..8cc8aab4d2 100644
 --- a/config.c
 +++ b/config.c
-@@ -9,6 +9,9 @@
- #define USE_THE_REPOSITORY_VARIABLE
- 
- #include "git-compat-util.h"
+@@ -33,6 +33,9 @@
+ #include "object-store-ll.h"
+ #include "pager.h"
+ #include "path.h"
 +#ifdef __MVS__
 +#include "read-cache-ll.h"
 +#endif
- #include "abspath.h"
- #include "advice.h"
- #include "date.h"
-@@ -1545,6 +1548,18 @@ static int git_default_core_config(const char *var, const char *value,
+ #include "utf8.h"
+ #include "color.h"
+ #include "refs.h"
+@@ -1508,6 +1511,18 @@ static int git_default_core_config(const char *var, const char *value,
  		return 0;
  	}
  

--- a/stable-patches/generate-perl.sh.patch
+++ b/stable-patches/generate-perl.sh.patch
@@ -1,0 +1,13 @@
+diff --git a/generate-perl.sh b/generate-perl.sh
+index 65f122ebfc..154ae533f8 100755
+--- a/generate-perl.sh
++++ b/generate-perl.sh
+@@ -19,7 +19,7 @@ OUTPUT="$5"
+ 
+ sed -e '1{' \
+     -e "	/^#!.*perl/!b" \
+-    -e "	s|#!.*perl|#!$PERL_PATH|" \
++    -e "	s|#!.*perl|#!$PERL_PATH_FOR_SCRIPTS|" \
+     -e "	r $PERL_HEADER" \
+     -e '	G' \
+     -e '}' \

--- a/stable-patches/http.c.patch
+++ b/stable-patches/http.c.patch
@@ -1,24 +1,8 @@
 diff --git a/http.c b/http.c
-index 623ed23489..145413a57c 100644
+index c8fc15aa11..d72d87f27e 100644
 --- a/http.c
 +++ b/http.c
-@@ -1037,6 +1037,15 @@ static int get_curl_http_version_opt(const char *version_string, long *opt)
- 
- #endif
- 
-+static void set_from_env(char **var, const char *envname)
-+{
-+	const char *val = getenv(envname);
-+	if (val) {
-+		FREE_AND_NULL(*var);
-+		*var = xstrdup(val);
-+	}
-+}
-+
- static CURL *get_curl_handle(void)
- {
- 	CURL *result = curl_easy_init();
-@@ -1116,7 +1125,6 @@ static CURL *get_curl_handle(void)
+@@ -1073,7 +1073,6 @@ static CURL *get_curl_handle(void)
  	if (ssl_cipherlist != NULL && *ssl_cipherlist)
  		curl_easy_setopt(result, CURLOPT_SSL_CIPHER_LIST,
  				ssl_cipherlist);
@@ -26,23 +10,7 @@ index 623ed23489..145413a57c 100644
  	if (ssl_cert)
  		curl_easy_setopt(result, CURLOPT_SSLCERT, ssl_cert);
  	if (ssl_cert_type)
-@@ -1277,15 +1285,6 @@ static CURL *get_curl_handle(void)
- 	return result;
- }
- 
--static void set_from_env(char **var, const char *envname)
--{
--	const char *val = getenv(envname);
--	if (val) {
--		FREE_AND_NULL(*var);
--		*var = xstrdup(val);
--	}
--}
--
- void http_init(struct remote *remote, const char *url, int proactive_auth)
- {
- 	char *low_speed_limit;
-@@ -1367,6 +1366,10 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
+@@ -1336,6 +1335,10 @@ void http_init(struct remote *remote, const char *url, int proactive_auth)
  	set_from_env(&ssl_key_type, "GIT_SSL_KEY_TYPE");
  	set_from_env(&ssl_capath, "GIT_SSL_CAPATH");
  	set_from_env(&ssl_cainfo, "GIT_SSL_CAINFO");

--- a/stable-patches/utf8.c.patch
+++ b/stable-patches/utf8.c.patch
@@ -1,17 +1,18 @@
 diff --git a/utf8.c b/utf8.c
-index 6bfaefa28e..7e0e6e67ea 100644
+index 35a0251939..b5877f22f0 100644
 --- a/utf8.c
 +++ b/utf8.c
-@@ -1,5 +1,8 @@
-+#define USE_THE_REPOSITORY_VARIABLE
-+
+@@ -3,6 +3,9 @@
  #include "git-compat-util.h"
  #include "strbuf.h"
-+#include "environment.h"
  #include "utf8.h"
++#ifdef __MVS__
++extern int utf8_ccsid;
++#endif
  
  /* This code is originally from https://www.cl.cam.ac.uk/~mgk25/ucs/ */
-@@ -590,6 +593,20 @@ char *reencode_string_len(const char *in, size_t insz,
+ 
+@@ -592,6 +595,20 @@ char *reencode_string_len(const char *in, size_t insz,
  #endif
  	}
  


### PR DESCRIPTION
It also fixes an issue where the RUNTIME prefix cannot be computed because GIT_EXEC_DIR, which is to be stripped, is an absolute path rather than a relative path. Therefore, the prefix directory cannot be computed.