### PR TITLE
Set lockfile tag to binary and ignore _ENCODE_FILE_NEW setting to avoid potential issues

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -171,6 +171,7 @@ GIT_EXEC_PATH|set|PROJECT_ROOT/libexec/git-core
 ZOPEN_GIT_SSL_CAINFO|set|PROJECT_ROOT/cacert.pem
 ASCII_TERMINFO|set|PROJECT_ROOT/../../ncurses/ncurses/share/terminfo/
 GIT_CONFIG_SYSTEM|set|PROJECT_ROOT/etc/gitconfig
+_ENCODE_FILE_NEW|unset|
 EOF
 }
 

--- a/stable-patches/archive.c.patch
+++ b/stable-patches/archive.c.patch
@@ -1,16 +1,14 @@
-diff --git a/builtin/archive.c b/builtin/archive.c
-index f094390..536b717 100644
---- a/builtin/archive.c
-+++ b/builtin/archive.c
-@@ -13,6 +13,12 @@
+diff --git i/builtin/archive.c w/builtin/archive.c
+index 13ea730..f0da605 100644
+--- i/builtin/archive.c
++++ w/builtin/archive.c
+@@ -12,6 +12,10 @@
  static void create_output_file(const char *output_file)
  {
  	int output_fd = xopen(output_file, O_CREAT | O_WRONLY | O_TRUNC, 0666);
 +#ifdef __MVS__
-+ #if (__CHARSET_LIB == 1)
-+        if (setbinaryfd(output_fd))
++        if (__setfdbinary(output_fd))
 +		die_errno(_("could not tag archive file '%s'"), output_file);
-+ #endif
 +#endif
  	if (output_fd != 1) {
  		if (dup2(output_fd, 1) < 0)

--- a/stable-patches/hash-object.c.patch
+++ b/stable-patches/hash-object.c.patch
@@ -1,43 +1,14 @@
-diff --git a/builtin/hash-object.c b/builtin/hash-object.c
-index fbae878..4c9c973 100644
---- a/builtin/hash-object.c
-+++ b/builtin/hash-object.c
-@@ -49,11 +49,39 @@ static void hash_fd(int fd, const char *type, const char *path, unsigned flags,
- 	maybe_flush_or_die(stdout, "hash to stdout");
- }
- 
-+#ifdef __MVS__
-+#  if (__CHARSET_LIB == 1)
-+#  include <stdio.h>
-+#  include <stdlib.h>
-+
-+   int setbinaryfd(int fd) 
-+   {
-+     attrib_t attr;
-+     int rc;
-+
-+     memset(&attr, 0, sizeof(attr));
-+     attr.att_filetagchg = 1;
-+     attr.att_filetag.ft_ccsid = FT_BINARY;
-+     attr.att_filetag.ft_txtflag = 0;
-+
-+     rc = __fchattr(fd, &attr, sizeof(attr));
-+     return rc;
-+   }
-+#  endif
-+#endif
-+
-+
- static void hash_object(const char *path, const char *type, const char *vpath,
- 			unsigned flags, int literally)
+diff --git i/builtin/hash-object.c w/builtin/hash-object.c
+index a25f040..40ab473 100644
+--- i/builtin/hash-object.c
++++ w/builtin/hash-object.c
+@@ -62,6 +62,10 @@ static void hash_object(const char *path, const char *type, const char *vpath,
  {
  	int fd;
  	fd = xopen(path, O_RDONLY);
 +#ifdef __MVS__
-+#  if (__CHARSET_LIB == 1)
-+  if (setbinaryfd(fd))
-+		die_errno("Cannot set to binary '%s'", path);
-+#  endif
++	if (__setfdbinary(fd))
++	  die_errno("Cannot set to binary '%s'", path);
 +#endif  
  	hash_fd(fd, type, vpath, flags, literally);
  }

--- a/stable-patches/lockfile.c.patch
+++ b/stable-patches/lockfile.c.patch
@@ -1,0 +1,14 @@
+diff --git i/lockfile.c w/lockfile.c
+index 1d5ed01..ca7ee77 100644
+--- i/lockfile.c
++++ w/lockfile.c
+@@ -83,6 +83,9 @@ static int lock_file(struct lock_file *lk, const char *path, int flags,
+ 
+ 	strbuf_addstr(&filename, LOCK_SUFFIX);
+ 	lk->tempfile = create_tempfile_mode(filename.buf, mode);
++#ifdef __MVS__
++	__setfdbinary(lk->tempfile->fd);
++#endif
+ 	strbuf_release(&filename);
+ 	return lk->tempfile ? lk->tempfile->fd : -1;
+ }


### PR DESCRIPTION
_ENCODE_FILE_NEW can affect the creation of Git's internal files, which could cause issues if they have UTF-8 content and if _ENCODE_FILE_NEW is set to IBM-1047. 

This change modifies Git to ignore the _ENCODE_FILE_NEW setting during the Git process. 

Related: https://github.com/zopencommunity/gitport/issues/141