### PR TITLE
Workaround for TZ being ignored by using EBCDIC localtime_r

### DIFF
--- a/stable-patches/date.c.patch
+++ b/stable-patches/date.c.patch
@@ -1,0 +1,23 @@
+diff --git i/date.c w/date.c
+index 17a9507..be63eb6 100644
+--- i/date.c
++++ w/date.c
+@@ -6,12 +6,18 @@
+ 
+ #define DISABLE_SIGN_COMPARE_WARNINGS
+ 
++//FIXME: localtime_r has an LE bug where it does not respect the TZ environment variable
++#define localtime_r localtime_r_replaced
+ #include "git-compat-util.h"
+ #include "date.h"
+ #include "gettext.h"
+ #include "pager.h"
+ #include "strbuf.h"
++#undef localtime_r
+ 
++//FIXME: localtime_r has an LE bug where it does not respect the TZ environment variable
++// Use the EBCDIC symbol instead
++struct tm *localtime_r(const time_t *timep, struct tm *result) asm("@@LCLT@R"); 
+ /*
+  * This is like mktime, but without normalization of tm_wday and tm_yday.
+  */


### PR DESCRIPTION
This PR resolves an intermittent issue on z/OS where Git fails to respect the TZ environment variable when formatting timestamps for commits and logs.

In some environments, localtime_r returns a UTC-based struct tm even when TZ is correctly set (e.g., CST6CDT). This leads to all timestamps being reported in UTC, regardless of the expected local time zone.

---

Git is built in ASCII mode, and the default symbol resolution maps localtime_r to the ASCII (@@A00337) implementation. However, on z/OS, this version intermittently fails to apply the TZ setting correctly. When the EBCDIC version (@@LCLT@R) is explicitly used, the correct local time is returned consistently. We will use this workaround until the LE team resolves the underlying issue.