### PR TITLE
Enabling tracing on utime to monitor "INSUFFICIENT AUTHORITY TO UTIME" racf messages

### DIFF
--- a/stable-patches/object-file.c.patch
+++ b/stable-patches/object-file.c.patch
@@ -1,8 +1,8 @@
 diff --git i/object-file.c w/object-file.c
-index 1ac04c2..63c0576 100644
+index 1ac04c2..7033988 100644
 --- i/object-file.c
 +++ w/object-file.c
-@@ -29,6 +29,77 @@
+@@ -29,6 +29,78 @@
  #include "setup.h"
  #include "streaming.h"
  
@@ -46,8 +46,9 @@ index 1ac04c2..63c0576 100644
 +        }
 +
 +        if (stat(fn, &st) == 0) {
-+            __console_printf("utime called on: %s\nOwner (%d), Group: (%d), EUID: %d, Args: %s\n",
++            __console_printf("utime called on: %s\nPID: %d, Owner (%d), Group: (%d), EUID: %d, Args: %s\n",
 +                           path_to_report,
++			   getpid(),
 +                           st.st_uid,
 +                           st.st_gid,
 +                           euid,  cmdline[0] ? cmdline : "unavailable"
@@ -80,7 +81,7 @@ index 1ac04c2..63c0576 100644
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -1280,18 +1351,88 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -1280,18 +1352,88 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  

--- a/stable-patches/object-file.c.patch
+++ b/stable-patches/object-file.c.patch
@@ -1,20 +1,86 @@
 diff --git i/object-file.c w/object-file.c
-index 1ac04c2..7e8bb2b 100644
+index 1ac04c2..63c0576 100644
 --- i/object-file.c
 +++ w/object-file.c
-@@ -29,6 +29,11 @@
+@@ -29,6 +29,77 @@
  #include "setup.h"
  #include "streaming.h"
  
++/* FIXME: tracing for utime which currently randomly emits RACF errors */
 +#ifdef __MVS__
 +#include <_Ccsid.h>
 +#include "read-cache-ll.h"
 +#endif
++int git_utime(const char *fn, const struct utimbuf *times) {
++    int rc = __utime_a(fn, times);
++    int saved_errno = errno; 
++
++    if (rc < 0) {
++        char abspath[PATH_MAX];
++        const char *resolved = realpath(fn, abspath);
++        const char *path_to_report = resolved ? resolved : fn;
++
++        struct stat st;
++        uid_t euid = geteuid();
++        gid_t egid = getegid();
++
++        // Get command-line arguments
++        char **argv = __getargv();
++        char cmdline[2048] = "";
++        if (argv) {
++            for (int i = 0; argv[i]; i++) {
++                int len = strlen(cmdline);
++                snprintf(cmdline + len, sizeof(cmdline) - len,
++                         "%s%s", i > 0 ? " " : "", argv[i]);
++            }
++        }
++
++        __console_printf("If you see this message, inform the zopen community!\n");
++
++        /* --- DEBUG: Print the values of the 'times' struct --- */
++        if (times) {
++            __console_printf("utime failed with times->actime: %ld, times->modtime: %ld\n",
++                           (long)times->actime, (long)times->modtime);
++        } else {
++            __console_printf("utime failed with NULL times argument\n");
++        }
++
++        if (stat(fn, &st) == 0) {
++            __console_printf("utime called on: %s\nOwner (%d), Group: (%d), EUID: %d, Args: %s\n",
++                           path_to_report,
++                           st.st_uid,
++                           st.st_gid,
++                           euid,  cmdline[0] ? cmdline : "unavailable"
++            );
++        } else {
++            __console_printf("utime called on: %s\n(stat failed)\n", path_to_report);
++        }
++
++        void *buffer[4096];
++        int nptrs = backtrace(buffer, 4096);
++        __console_printf("Backtrace:\n");
++        
++        char **symbols = backtrace_symbols(buffer, nptrs);
++
++        if (symbols) {
++            // Loop through the returned strings and print them
++            for (int i = 0; symbols[i]; i++) {
++                __console_printf("%s\n", symbols[i]);
++            }
++            // Free the memory allocated by the backtrace function
++            free(symbols);
++        }
++
++    }
++    errno = saved_errno;
++
++    return rc;
++}
 +
  /* The maximum size for an object header. */
  #define MAX_HEADER_LEN 32
  
-@@ -1280,18 +1285,88 @@ int index_fd(struct index_state *istate, struct object_id *oid,
+@@ -1280,18 +1351,88 @@ int index_fd(struct index_state *istate, struct object_id *oid,
  	return ret;
  }
  

--- a/stable-patches/posix.h.patch
+++ b/stable-patches/posix.h.patch
@@ -1,0 +1,20 @@
+diff --git i/compat/posix.h w/compat/posix.h
+index 067a00f..1974083 100644
+--- i/compat/posix.h
++++ w/compat/posix.h
+@@ -284,6 +284,15 @@ int git_munmap(void *start, size_t length);
+ #define MAP_FAILED ((void *)-1)
+ #endif
+ 
++/* FIXME: utime is resulting in RACF messages, use git_utime to trace */
++#ifdef __MVS__
++#ifdef utime
++#undef utime
++#endif
++#define utime(path, times) git_utime(path, times)
++int git_utime(const char *path, const struct utimbuf *times);
++#endif
++
+ #ifdef NEEDS_MODE_TRANSLATION
+ #undef S_IFMT
+ #undef S_IFREG


### PR DESCRIPTION
Git is currently emitting " INSUFFICIENT AUTHORITY TO UTIME " operator messages. We're still not able to reproduce this manually, and therefore this PR will add tracing information to give us insights into what commands or circumstances lead to this issue.

```
  INSUFFICIENT AUTHORITY TO UTIME                                   

  ACCESS INTENT(-W-)  ACCESS ALLOWED(OWNER      R--)    
```